### PR TITLE
refactor: elimina referencia circular entre Subject y Group

### DIFF
--- a/src/main/java/com/example/fantasticosback/Controller/StudentController.java
+++ b/src/main/java/com/example/fantasticosback/Controller/StudentController.java
@@ -176,4 +176,51 @@ public class StudentController {
             return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
         }
     }
+
+
+    // Endpoint para visualizar el horario actual de un estudiante
+    @GetMapping("/{studentId}/schedule")
+    public ResponseEntity<ResponseDTO<List<Object>>> getStudentCurrentSchedule(@PathVariable String studentId) {
+        try {
+            List<Object> schedule = studentService.getCurrentSubjects(studentId);
+            return ResponseEntity.ok(ResponseDTO.success(schedule,
+                "Current schedule retrieved for student " + studentId));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(ResponseDTO.error("Student not found: " + e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
+        }
+    }
+
+    // Endpoint para visualizar el horario de un semestre específico del estudiante
+    @GetMapping("/{studentId}/schedule/semester/{semesterNumber}")
+    public ResponseEntity<ResponseDTO<List<Object>>> getStudentScheduleBySemester(
+            @PathVariable String studentId,
+            @PathVariable int semesterNumber) {
+        try {
+            // Convertir número de semestre a índice (semesterNumber - 1)
+            List<Object> schedule = studentService.getStudentScheduleBySemester(studentId, semesterNumber - 1);
+            return ResponseEntity.ok(ResponseDTO.success(schedule,
+                "Schedule retrieved for student " + studentId + " semester " + semesterNumber));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(ResponseDTO.error("Error: " + e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
+        }
+    }
+
+    // Endpoint para visualizar el historial completo de horarios del estudiante
+    @GetMapping("/{studentId}/schedule/history")
+    public ResponseEntity<ResponseDTO<Object>> getStudentAllSchedules(@PathVariable String studentId) {
+        try {
+            // Aquí necesitaremos agregar este método al StudentService
+            Object allSchedules = studentService.getStudentAllSchedules(studentId);
+            return ResponseEntity.ok(ResponseDTO.success(allSchedules,
+                "Complete schedule history retrieved for student " + studentId));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(ResponseDTO.error("Student not found: " + e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/example/fantasticosback/Controller/SubjectController.java
+++ b/src/main/java/com/example/fantasticosback/Controller/SubjectController.java
@@ -4,6 +4,7 @@ import com.example.fantasticosback.Dtos.ResponseDTO;
 import com.example.fantasticosback.Dtos.SubjectDTO;
 import com.example.fantasticosback.Server.SubjectService;
 import com.example.fantasticosback.Model.Subject;
+import com.example.fantasticosback.util.ClassSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -70,6 +71,64 @@ public class SubjectController {
             return ResponseEntity.ok(ResponseDTO.success(groups, "Groups retrieved for " + subjectCode));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(404).body(ResponseDTO.error("Subject not found: " + e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
+        }
+    }
+
+    // Endpoint para añadir una sesión de clase a un grupo específico
+    @PostMapping("/{subjectCode}/groups/{groupId}/sessions")
+    public ResponseEntity<ResponseDTO<String>> addSessionToGroup(
+            @PathVariable String subjectCode,
+            @PathVariable int groupId,
+            @RequestBody ClassSession session) {
+        try {
+            boolean success = subjectService.addSessionToGroup(subjectCode, groupId, session);
+            if (success) {
+                return ResponseEntity.ok(ResponseDTO.success("Session added successfully",
+                        "Session added to group " + groupId + " in subject " + subjectCode));
+            } else {
+                return ResponseEntity.badRequest().body(ResponseDTO.error("Failed to add session to group"));
+            }
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(ResponseDTO.error("Error: " + e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
+        }
+    }
+
+    // Endpoint para obtener las sesiones de un grupo específico
+    @GetMapping("/{subjectCode}/groups/{groupId}/sessions")
+    public ResponseEntity<ResponseDTO<List<ClassSession>>> getGroupSessions(
+            @PathVariable String subjectCode,
+            @PathVariable int groupId) {
+        try {
+            List<ClassSession> sessions = subjectService.getGroupSessions(subjectCode, groupId);
+            return ResponseEntity.ok(ResponseDTO.success(sessions,
+                    "Sessions retrieved for group " + groupId + " in subject " + subjectCode));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(ResponseDTO.error("Error: " + e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
+        }
+    }
+
+    // Endpoint para eliminar una sesión específica de un grupo
+    @DeleteMapping("/{subjectCode}/groups/{groupId}/sessions/{sessionIndex}")
+    public ResponseEntity<ResponseDTO<String>> removeSessionFromGroup(
+            @PathVariable String subjectCode,
+            @PathVariable int groupId,
+            @PathVariable int sessionIndex) {
+        try {
+            boolean success = subjectService.removeSessionFromGroup(subjectCode, groupId, sessionIndex);
+            if (success) {
+                return ResponseEntity.ok(ResponseDTO.success("Session removed successfully",
+                        "Session " + sessionIndex + " removed from group " + groupId + " in subject " + subjectCode));
+            } else {
+                return ResponseEntity.badRequest().body(ResponseDTO.error("Failed to remove session from group"));
+            }
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(ResponseDTO.error("Error: " + e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(500).body(ResponseDTO.error("Internal error: " + e.getMessage()));
         }

--- a/src/main/java/com/example/fantasticosback/Model/Enrollment.java
+++ b/src/main/java/com/example/fantasticosback/Model/Enrollment.java
@@ -4,13 +4,15 @@ import com.example.fantasticosback.util.ClassSession;
 
 public class Enrollment {
     private Group group;
+    private Subject subject;
     private int id;
     private String status;
     private double finalGrade;
 
 
-    public Enrollment(Group group, int id, String status, double finalGrade) {
+    public Enrollment(Group group, Subject subject, int id, String status, double finalGrade) {
         this.group = group;
+        this.subject = subject;
         this.id = id;
         this.status = status;
         this.finalGrade = finalGrade;
@@ -19,6 +21,14 @@ public class Enrollment {
     // Getters y Setters
     public Group getGroup() {
         return group;
+    }
+
+    public Subject getSubject() {
+        return subject;
+    }
+
+    public void setSubject(Subject subject) {
+        this.subject = subject;
     }
 
     public int getId() {

--- a/src/main/java/com/example/fantasticosback/Model/Group.java
+++ b/src/main/java/com/example/fantasticosback/Model/Group.java
@@ -9,17 +9,15 @@ public class Group {
     private int number;
     private int capacity;
     private boolean active;
-    private Subject subject;
     private Teacher teacher;
     private ArrayList<Student> groupStudents;
     private ArrayList<ClassSession> sessions = new ArrayList<>();
 
-    public Group(int id, int number, int capacity, boolean active, Subject subject, Teacher teacher) {
+    public Group(int id, int number, int capacity, boolean active, Teacher teacher) {
         this.id = id;
         this.number = number;
         this.capacity = capacity;
         this.active = active;
-        this.subject = subject;
         this.teacher = teacher;
         this.groupStudents = new ArrayList<>();
         this.sessions = new ArrayList<>();
@@ -44,14 +42,6 @@ public class Group {
 
     public boolean isActive() {
         return active;
-    }
-
-    public Subject getSubject() {
-        return subject;
-    }
-
-    public void setSubject(Subject subject) {
-        this.subject = subject;
     }
 
     public Teacher getTeacher() {

--- a/src/main/java/com/example/fantasticosback/Model/Semester.java
+++ b/src/main/java/com/example/fantasticosback/Model/Semester.java
@@ -87,7 +87,7 @@ public class Semester {
         int totalCredits = 0;
 
         for (Enrollment enrollment : subjects) {
-            int credits = enrollment.getGroup().getSubject().getCredits();
+            int credits = enrollment.getSubject().getCredits();
             double grade = enrollment.getFinalGrade();
 
             gradeCreditsSum += grade * credits;

--- a/src/main/java/com/example/fantasticosback/Model/Student.java
+++ b/src/main/java/com/example/fantasticosback/Model/Student.java
@@ -75,42 +75,42 @@ public class Student extends Person {
         this.studentId = _id;
     }
 
-    public boolean verifyScheduleConflict(Group desiredGroup) {
+    public boolean verifyScheduleConflict(Group desiredGroup, Subject desiredSubject) {
         if (semesters.isEmpty()) {
             return false;
         }
 
         Semester currentSemester = semesters.get(semesters.size() - 1);
-        Enrollment temporaryEnrollment = new Enrollment(desiredGroup, 0, "studying", 0.0);
+        Enrollment temporaryEnrollment = new Enrollment(desiredGroup, desiredSubject, 0, "studying", 0.0);
 
         for (Enrollment existingEnrollment : currentSemester.getSubjects()) {
             if (temporaryEnrollment.validateConflict(existingEnrollment)) {
                 log.warning("Group " + desiredGroup.getNumber() +
-                        " conflicts with " + existingEnrollment.getGroup().getSubject().getName());
+                        " conflicts with " + existingEnrollment.getSubject().getName());
                 return true;
             }
         }
         return false;
     }
 
-    public boolean addSubject(Group chosenGroup) {
+    public boolean addSubject(Group chosenGroup, Subject subject) {
         if (!chosenGroup.isActive()) {
             log.warning("Group " + chosenGroup.getNumber() + " is not active.");
             return false;
         }
 
-        if (verifyScheduleConflict(chosenGroup)) {
+        if (verifyScheduleConflict(chosenGroup, subject)) {
             log.warning("Cannot enroll: schedule conflict.");
             return false;
         }
 
         int enrollmentId = (int) (Math.random() * 100000);
-        Enrollment newEnrollment = new Enrollment(chosenGroup, enrollmentId, "active", 0.0);
+        Enrollment newEnrollment = new Enrollment(chosenGroup, subject, enrollmentId, "active", 0.0);
 
         if (!semesters.isEmpty()) {
             semesters.get(semesters.size() - 1).addSubject(newEnrollment);
             log.info("Successful enrollment in group " + chosenGroup.getNumber() +
-                    " of " + chosenGroup.getSubject().getName());
+                    " of " + subject.getName());
             return true;
         }
 
@@ -122,7 +122,7 @@ public class Student extends Person {
         if (!semesters.isEmpty()) {
             Semester currentSemester = semesters.get(semesters.size() - 1);
             currentSemester.removeSubject(enrollment);
-            log.info("Subject " + enrollment.getGroup().getSubject().getName() + " withdrawn successfully.");
+            log.info("Subject " + enrollment.getSubject().getName() + " withdrawn successfully.");
         } else {
             log.warning("No active semester to remove the subject.");
         }
@@ -132,7 +132,7 @@ public class Student extends Person {
         if (!semesters.isEmpty()) {
             Semester currentSemester = semesters.get(semesters.size() - 1);
             currentSemester.cancelSubject(enrollment);
-            log.info("Subject " + enrollment.getGroup().getSubject().getName() + " cancelled successfully.");
+            log.info("Subject " + enrollment.getSubject().getName() + " cancelled successfully.");
         } else {
             log.warning("No active semester to cancel the subject.");
         }
@@ -148,7 +148,7 @@ public class Student extends Person {
         }
     }
 
-    public Request createRequest(String type, Enrollment currentSubject, Group destinationGroup, String observations) {
+    public Request createRequest(String type, Enrollment currentSubject, Group destinationGroup, Subject destinationSubject, String observations) {
         String requestId = String.valueOf((int) (Math.random() * 100000));
         Date currentDate = new Date();
 
@@ -167,8 +167,8 @@ public class Student extends Person {
                     " from group " + currentSubject.getGroup().getNumber() + " to group " + destinationGroup.getNumber());
         } else if ("subject".equals(type)) {
             log.info("Subject change request created: ID " + requestId +
-                    " from subject " + currentSubject.getGroup().getSubject().getName() +
-                    " to subject " + destinationGroup.getSubject().getName());
+                    " from subject " + currentSubject.getSubject().getName() +
+                    " to subject " + destinationSubject.getName());
         }
         alertObserver(request);
         requests.add(request);

--- a/src/main/java/com/example/fantasticosback/Server/ScheduleService.java
+++ b/src/main/java/com/example/fantasticosback/Server/ScheduleService.java
@@ -141,7 +141,7 @@ public class ScheduleService {
     private List<Map<String, Object>> generateEnrollmentClasses(Enrollment enrollment) {
         List<Map<String, Object>> classes = new ArrayList<>();
         Group group = enrollment.getGroup();
-        Subject subject = group.getSubject();
+        Subject subject = enrollment.getSubject();
         Teacher teacher = group.getTeacher();
 
         String teacherName = (teacher != null) ?

--- a/src/main/java/com/example/fantasticosback/Server/StudentService.java
+++ b/src/main/java/com/example/fantasticosback/Server/StudentService.java
@@ -1,3 +1,4 @@
+// Solo guardar el estudiante - la materia no cambia
 package com.example.fantasticosback.Server;
 
 import com.example.fantasticosback.Dtos.StudentDTO;
@@ -10,13 +11,15 @@ import com.example.fantasticosback.Model.Enrollment;
 import com.example.fantasticosback.util.SubjectCatalog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.logging.Logger;
 
 @Service
 public class StudentService {
+
+    private static final Logger log = Logger.getLogger(StudentService.class.getName());
 
     @Autowired
     private StudentRepository studentRepository;
@@ -142,7 +145,6 @@ public class StudentService {
             throw new IllegalArgumentException("Student not found with ID: " + studentId);
         }
 
-        // Usar el método real implementado en el modelo Student
         return student.getCurrentSchedule().stream()
                 .map(enrollment -> Map.of(
                     "enrollmentId", enrollment.getId(),
@@ -152,7 +154,15 @@ public class StudentService {
                     "status", enrollment.getStatus(),
                     "credits", enrollment.getSubject().getCredits(),
                     "teacherName", enrollment.getGroup().getTeacher() != null ?
-                        enrollment.getGroup().getTeacher().getName() + " " + enrollment.getGroup().getTeacher().getLastName() : "No asignado"
+                        enrollment.getGroup().getTeacher().getName() + " " + enrollment.getGroup().getTeacher().getLastName() : "No asignado",
+                    "classSessions", enrollment.getGroup().getSessions().stream()
+                        .map(session -> Map.of(
+                            "day", session.getDay(),
+                            "startTime", session.getStartTime(),
+                            "endTime", session.getEndTime(),
+                            "classroom", session.getClassroom()
+                        ))
+                        .collect(Collectors.toList())
                 ))
                 .collect(Collectors.toList());
     }
@@ -197,18 +207,21 @@ public class StudentService {
 
         return subject.getAvailableGroups().stream()
                 .filter(Group::isActive) // Solo grupos activos
-                .map(group -> Map.of(
-                    "groupId", group.getId(),
-                    "groupNumber", group.getNumber(),
-                    "capacity", group.getCapacity(),
-                    "enrolled", group.getGroupStudents().size(),
-                    "available", group.getCapacity() - group.getGroupStudents().size(),
-                    "teacherName", group.getTeacher() != null ?
-                        group.getTeacher().getName() + " " + group.getTeacher().getLastName() : "No asignado",
-                    "schedule", group.getSessions().stream()
-                        .map(session -> session.getDay() + " " + session.getStartTime() + "-" + session.getEndTime())
-                        .collect(Collectors.toList())
-                ))
+                .map(group -> {
+                    int enrolledCount = getAllStudentsInGroup(group.getId()).size();
+                    return Map.of(
+                        "groupId", group.getId(),
+                        "groupNumber", group.getNumber(),
+                        "capacity", group.getCapacity(),
+                        "enrolled", enrolledCount,
+                        "available", group.getCapacity() - enrolledCount,
+                        "teacherName", group.getTeacher() != null ?
+                            group.getTeacher().getName() + " " + group.getTeacher().getLastName() : "No asignado",
+                        "schedule", group.getSessions().stream()
+                            .map(session -> session.getDay() + " " + session.getStartTime() + "-" + session.getEndTime())
+                            .collect(Collectors.toList())
+                    );
+                })
                 .collect(Collectors.toList());
     }
 
@@ -269,20 +282,23 @@ public class StudentService {
 
         return subject.getAvailableGroups().stream()
                 .filter(Group::isActive) // Solo grupos activos
-                .map(group -> Map.of(
-                    "groupId", group.getId(),
-                    "groupNumber", group.getNumber(),
-                    "capacity", group.getCapacity(),
-                    "enrolled", group.getGroupStudents().size(),
-                    "available", group.getCapacity() - group.getGroupStudents().size(),
-                    "teacherName", group.getTeacher() != null ?
-                        group.getTeacher().getName() + " " + group.getTeacher().getLastName() : "No asignado",
-                    "schedule", group.getSessions().stream()
-                        .map(session -> session.getDay() + " " + session.getStartTime() + "-" + session.getEndTime())
-                        .collect(Collectors.toList()),
-                    "subjectCode", subjectCode,
-                    "subjectName", subject.getName()
-                ))
+                .map(group -> {
+                    int enrolledCount = getAllStudentsInGroup(group.getId()).size();
+                    return Map.of(
+                        "groupId", group.getId(),
+                        "groupNumber", group.getNumber(),
+                        "capacity", group.getCapacity(),
+                        "enrolled", enrolledCount,
+                        "available", group.getCapacity() - enrolledCount,
+                        "teacherName", group.getTeacher() != null ?
+                            group.getTeacher().getName() + " " + group.getTeacher().getLastName() : "No asignado",
+                        "schedule", group.getSessions().stream()
+                            .map(session -> session.getDay() + " " + session.getStartTime() + "-" + session.getEndTime())
+                            .collect(Collectors.toList()),
+                        "subjectCode", subjectCode,
+                        "subjectName", subject.getName()
+                    );
+                })
                 .collect(Collectors.toList());
     }
 
@@ -317,12 +333,39 @@ public class StudentService {
             throw new IllegalArgumentException("Group not found with ID: " + groupId + " in subject: " + subjectCode);
         }
 
-        // Usar el método real del modelo Student con ambos parámetros
+        // Verificar si el grupo tiene capacidad disponible
+        long enrolledCount = getAllStudentsInGroup(targetGroup.getId()).size();
+        if (enrolledCount >= targetGroup.getCapacity()) {
+            log.warning("Group " + groupId + " is at full capacity");
+            return false;
+        }
+
+        // Usar el método real del modelo Student with ambos parámetros
         boolean success = student.addSubject(targetGroup, subject);
         if (success) {
+            // NO agregar el estudiante al grupo manualmente - esto causa la referencia circular
+            // La relación se mantiene a través del Enrollment
+
+            // Solo guardar el estudiante
             studentRepository.save(student);
+
+            log.info("Student " + studentId + " successfully enrolled in " + subjectCode + " group " + groupId);
+        } else {
+            log.warning("Failed to enroll student " + studentId + " in " + subjectCode + " group " + groupId);
         }
         return success;
+    }
+
+    /**
+     * Método auxiliar para obtener todos los estudiantes inscritos en un grupo específico
+     * Busca dinámicamente en lugar de usar la lista groupStudents
+     */
+    private List<Student> getAllStudentsInGroup(int groupId) {
+        List<Student> allStudents = studentRepository.findAll();
+        return allStudents.stream()
+                .filter(student -> student.getCurrentSchedule().stream()
+                        .anyMatch(enrollment -> enrollment.getGroup().getId() == groupId))
+                .collect(Collectors.toList());
     }
 
     // Métodos auxiliares
@@ -364,5 +407,73 @@ public class StudentService {
                         .anyMatch(group -> String.valueOf(group.getId()).equals(groupId)))
                 .findFirst()
                 .orElse(null);
+    }
+
+    /**
+     * Obtiene el horario de un semestre específico del estudiante
+     */
+    public List<Object> getStudentScheduleBySemester(String studentId, int semesterIndex) {
+        Student student = findById(studentId);
+        if (student == null) {
+            throw new IllegalArgumentException("Student not found with ID: " + studentId);
+        }
+
+        return student.getScheduleBySemester(semesterIndex).stream()
+                .map(enrollment -> Map.of(
+                    "enrollmentId", enrollment.getId(),
+                    "subjectName", enrollment.getSubject().getName(),
+                    "subjectId", enrollment.getSubject().getSubjectId(),
+                    "groupNumber", enrollment.getGroup().getNumber(),
+                    "status", enrollment.getStatus(),
+                    "credits", enrollment.getSubject().getCredits(),
+                    "finalGrade", enrollment.getFinalGrade(),
+                    "teacherName", enrollment.getGroup().getTeacher() != null ?
+                        enrollment.getGroup().getTeacher().getName() + " " + enrollment.getGroup().getTeacher().getLastName() : "No asignado",
+                    "classSessions", enrollment.getGroup().getSessions().stream()
+                        .map(session -> Map.of(
+                            "day", session.getDay(),
+                            "startTime", session.getStartTime(),
+                            "endTime", session.getEndTime(),
+                            "classroom", session.getClassroom()
+                        ))
+                        .collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Obtiene el historial completo de horarios del estudiante
+     */
+    public Object getStudentAllSchedules(String studentId) {
+        Student student = findById(studentId);
+        if (student == null) {
+            throw new IllegalArgumentException("Student not found with ID: " + studentId);
+        }
+
+        return student.getAllSchedules().entrySet().stream()
+                .collect(Collectors.toMap(
+                    entry -> "Semester " + entry.getKey(),
+                    entry -> entry.getValue().stream()
+                        .map(enrollment -> Map.of(
+                            "enrollmentId", enrollment.getId(),
+                            "subjectName", enrollment.getSubject().getName(),
+                            "subjectId", enrollment.getSubject().getSubjectId(),
+                            "groupNumber", enrollment.getGroup().getNumber(),
+                            "status", enrollment.getStatus(),
+                            "credits", enrollment.getSubject().getCredits(),
+                            "finalGrade", enrollment.getFinalGrade(),
+                            "teacherName", enrollment.getGroup().getTeacher() != null ?
+                                enrollment.getGroup().getTeacher().getName() + " " + enrollment.getGroup().getTeacher().getLastName() : "No asignado",
+                            "classSessions", enrollment.getGroup().getSessions().stream()
+                                .map(session -> Map.of(
+                                    "day", session.getDay(),
+                                    "startTime", session.getStartTime(),
+                                    "endTime", session.getEndTime(),
+                                    "classroom", session.getClassroom()
+                                ))
+                                .collect(Collectors.toList())
+                        ))
+                        .collect(Collectors.toList())
+                ));
     }
 }

--- a/src/main/java/com/example/fantasticosback/Server/SubjectService.java
+++ b/src/main/java/com/example/fantasticosback/Server/SubjectService.java
@@ -8,6 +8,7 @@ import com.example.fantasticosback.Model.Subject;
 import com.example.fantasticosback.Model.Group;
 import com.example.fantasticosback.Model.Teacher;
 import com.example.fantasticosback.util.SubjectCatalog;
+import com.example.fantasticosback.util.ClassSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -219,5 +220,114 @@ public class SubjectService {
                     "subjectName", subject.getName()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Añade una sesión de clase a un grupo específico de una materia
+     */
+    public boolean addSessionToGroup(String subjectCode, int groupId, ClassSession session) {
+        // Obtener la materia del catálogo usando la abreviatura
+        Subject catalogSubject = SubjectCatalog.getSubject(subjectCode);
+        if (catalogSubject == null) {
+            throw new IllegalArgumentException("Subject not found in catalog with code: " + subjectCode);
+        }
+
+        // Buscar la materia en la BD usando el ID del catálogo
+        Subject subject = findById(catalogSubject.getSubjectId());
+        if (subject == null) {
+            throw new IllegalArgumentException("Subject not found in database with code: " + subjectCode);
+        }
+
+        // Buscar el grupo específico
+        Group targetGroup = subject.getAvailableGroups().stream()
+                .filter(group -> group.getId() == groupId)
+                .findFirst()
+                .orElse(null);
+
+        if (targetGroup == null) {
+            throw new IllegalArgumentException("Group not found with ID: " + groupId + " in subject: " + subjectCode);
+        }
+
+        // Verificar conflictos de horario dentro del mismo grupo
+        for (ClassSession existingSession : targetGroup.getSessions()) {
+            if (existingSession.verifyConflict(session)) {
+                throw new IllegalArgumentException("Schedule conflict detected. Session overlaps with existing session on " +
+                    existingSession.getDay() + " from " + existingSession.getStartTime() + " to " + existingSession.getEndTime());
+            }
+        }
+
+        // Añadir la sesión al grupo
+        targetGroup.addSession(session);
+
+        // Guardar la materia actualizada
+        subjectRepository.save(subject);
+        return true;
+    }
+
+    /**
+     * Obtiene las sesiones de un grupo específico
+     */
+    public List<ClassSession> getGroupSessions(String subjectCode, int groupId) {
+        // Obtener la materia del catálogo usando la abreviatura
+        Subject catalogSubject = SubjectCatalog.getSubject(subjectCode);
+        if (catalogSubject == null) {
+            throw new IllegalArgumentException("Subject not found in catalog with code: " + subjectCode);
+        }
+
+        // Buscar la materia en la BD usando el ID del catálogo
+        Subject subject = findById(catalogSubject.getSubjectId());
+        if (subject == null) {
+            throw new IllegalArgumentException("Subject not found in database with code: " + subjectCode);
+        }
+
+        // Buscar el grupo específico
+        Group targetGroup = subject.getAvailableGroups().stream()
+                .filter(group -> group.getId() == groupId)
+                .findFirst()
+                .orElse(null);
+
+        if (targetGroup == null) {
+            throw new IllegalArgumentException("Group not found with ID: " + groupId + " in subject: " + subjectCode);
+        }
+
+        return targetGroup.getSessions();
+    }
+
+    /**
+     * Elimina una sesión específica de un grupo
+     */
+    public boolean removeSessionFromGroup(String subjectCode, int groupId, int sessionIndex) {
+        // Obtener la materia del catálogo usando la abreviatura
+        Subject catalogSubject = SubjectCatalog.getSubject(subjectCode);
+        if (catalogSubject == null) {
+            throw new IllegalArgumentException("Subject not found in catalog with code: " + subjectCode);
+        }
+
+        // Buscar la materia en la BD usando el ID del catálogo
+        Subject subject = findById(catalogSubject.getSubjectId());
+        if (subject == null) {
+            throw new IllegalArgumentException("Subject not found in database with code: " + subjectCode);
+        }
+
+        // Buscar el grupo específico
+        Group targetGroup = subject.getAvailableGroups().stream()
+                .filter(group -> group.getId() == groupId)
+                .findFirst()
+                .orElse(null);
+
+        if (targetGroup == null) {
+            throw new IllegalArgumentException("Group not found with ID: " + groupId + " in subject: " + subjectCode);
+        }
+
+        if (sessionIndex < 0 || sessionIndex >= targetGroup.getSessions().size()) {
+            throw new IllegalArgumentException("Invalid session index: " + sessionIndex);
+        }
+
+        // Eliminar la sesión
+        targetGroup.getSessions().remove(sessionIndex);
+
+        // Guardar la materia actualizada
+        subjectRepository.save(subject);
+        return true;
     }
 }

--- a/src/main/java/com/example/fantasticosback/Server/SubjectService.java
+++ b/src/main/java/com/example/fantasticosback/Server/SubjectService.java
@@ -87,13 +87,12 @@ public class SubjectService {
         // Generar ID único para el grupo
         int newGroupId = generateGroupId(subject);
 
-        // Crear el nuevo grupo
+        // Crear el nuevo grupo (sin la referencia a subject)
         Group newGroup = new Group(
             newGroupId,
             groupDto.getNumber(),
             groupDto.getCapacity(),
             groupDto.isActive(),
-            subject,
             teacher
         );
 
@@ -172,13 +171,12 @@ public class SubjectService {
         // Generar ID único para el grupo
         int newGroupId = generateGroupId(subject);
 
-        // Crear el nuevo grupo
+        // Crear el nuevo grupo (sin la referencia a subject)
         Group newGroup = new Group(
             newGroupId,
             groupDto.getNumber(),
             groupDto.getCapacity(),
             groupDto.isActive(),
-            subject,
             teacher
         );
 

--- a/src/main/java/com/example/fantasticosback/util/AcademicTrafficLight.java
+++ b/src/main/java/com/example/fantasticosback/util/AcademicTrafficLight.java
@@ -32,7 +32,7 @@ public class AcademicTrafficLight {
         this.approvedCredits = 0; // Reset counter
         for (Enrollment enrollment : subjects) {
             if (enrollment.getStatus().equals("approved")) {
-                approvedCredits += enrollment.getGroup().getSubject().getCredits();
+                approvedCredits += enrollment.getSubject().getCredits();
             }
         }
         calculateCumulativeAverage();
@@ -45,7 +45,7 @@ public class AcademicTrafficLight {
         int coursedCredits = 0;
 
         for (Enrollment enrollment : subjects) {
-            int credits = enrollment.getGroup().getSubject().getCredits();
+            int credits = enrollment.getSubject().getCredits();
             double grade = enrollment.getFinalGrade();
             gradeCreditsSum += grade * credits;
             coursedCredits += credits;

--- a/src/test/java/com/example/fantasticosback/Server/ScheduleServiceTest.java
+++ b/src/test/java/com/example/fantasticosback/Server/ScheduleServiceTest.java
@@ -63,17 +63,15 @@ class ScheduleServiceTest {
         Subject calculus = new Subject("1001", "Calculus I", 4, 1);
         Subject physics = new Subject("1002", "Physics I", 3, 1);
 
-        // Create groups with sessions
-        Group calculusGroup = new Group(1, 101, 30, true, calculus, teacher);
+        Group calculusGroup = new Group(1, 101, 30, true, teacher);
         calculusGroup.addSession(new ClassSession("Monday", "08:00", "10:00", "Room 101"));
         calculusGroup.addSession(new ClassSession("Wednesday", "08:00", "10:00", "Room 101"));
 
-        Group physicsGroup = new Group(2, 102, 25, true, physics, teacher);
+        Group physicsGroup = new Group(2, 102, 25, true, teacher);
         physicsGroup.addSession(new ClassSession("Tuesday", "10:00", "12:00", "Room 102"));
 
-        // Create enrollments
-        Enrollment calculusEnrollment = new Enrollment(calculusGroup, 1, "active", 0.0);
-        Enrollment physicsEnrollment = new Enrollment(physicsGroup, 2, "active", 0.0);
+        Enrollment calculusEnrollment = new Enrollment(calculusGroup, calculus, 1, "active", 0.0);
+        Enrollment physicsEnrollment = new Enrollment(physicsGroup, physics, 2, "active", 0.0);
 
         // Create active semester
         Semester currentSemester = new Semester(1, 2024, 1, true);

--- a/src/test/java/com/example/fantasticosback/Server/ScheduleServiceTest.java
+++ b/src/test/java/com/example/fantasticosback/Server/ScheduleServiceTest.java
@@ -45,14 +45,14 @@ class ScheduleServiceTest {
         // Create test student
         Career career = new Career("Systems Engineering", 160);
         AcademicTrafficLight academicTrafficLight = new AcademicTrafficLight(1, 0, career);
-        student = new Student("John", "Doe", 123456789, "Engineering", "C001", "E001", 5, academicTrafficLight);
+        student = new Student("John", "Doe", 123456789, "Systems Engineering", "C001", "E001", 5, academicTrafficLight);
 
         // Create test teacher
         teacher = new Teacher("Mary", "Smith", 987654321, "Mathematics");
         teacher.setId("T001");
 
         // Create test dean office
-        deanOffice = new DeanOffice("D001", "Engineering");
+        deanOffice = new DeanOffice("D001", "Systems Engineering");
 
         // Set up realistic student data with semester and enrollments
         setupStudentData();
@@ -70,16 +70,9 @@ class ScheduleServiceTest {
         Group physicsGroup = new Group(2, 102, 25, true, teacher);
         physicsGroup.addSession(new ClassSession("Tuesday", "10:00", "12:00", "Room 102"));
 
-        Enrollment calculusEnrollment = new Enrollment(calculusGroup, calculus, 1, "active", 0.0);
-        Enrollment physicsEnrollment = new Enrollment(physicsGroup, physics, 2, "active", 0.0);
-
-        // Create active semester
-        Semester currentSemester = new Semester(1, 2024, 1, true);
-        currentSemester.addSubject(calculusEnrollment);
-        currentSemester.addSubject(physicsEnrollment);
-
-        // Add semester to student
-        student.getSemesters().add(currentSemester);
+        // Agregar las materias al semestre actual (último semestre)
+        student.addSubject(calculusGroup, calculus);
+        student.addSubject(physicsGroup, physics);
     }
 
     @Test
@@ -94,11 +87,11 @@ class ScheduleServiceTest {
         assertNotNull(result);
         assertEquals("E001", result.get("studentId"));
         assertEquals("John Doe", result.get("studentName"));
-        assertEquals("Engineering", result.get("career"));
+        assertEquals("Systems Engineering", result.get("career"));
         assertEquals(5, result.get("semester"));
         assertInstanceOf(ArrayList.class, result.get("classes"));
         ArrayList<?> classes = (ArrayList<?>) result.get("classes");
-        assertEquals(3, classes.size()); // Three sessions total: 2 calculus + 1 physics
+        assertEquals(3, classes.size());
 
         verify(studentRepository).findById("E001");
     }
@@ -130,7 +123,7 @@ class ScheduleServiceTest {
         assertEquals("E001", result.get("studentId"));
         assertInstanceOf(ArrayList.class, result.get("classes"));
         ArrayList<?> classes = (ArrayList<?>) result.get("classes");
-        assertEquals(3, classes.size()); // Should be 3 classes total: 2 calculus + 1 physics
+        assertEquals(3, classes.size());
 
         verify(studentRepository).findById("E001");
         verify(teacherRepository).findById("T001");

--- a/src/test/java/com/example/fantasticosback/util/AcademicTrafficLightTest.java
+++ b/src/test/java/com/example/fantasticosback/util/AcademicTrafficLightTest.java
@@ -16,15 +16,17 @@ public class AcademicTrafficLightTest {
         Career career = new Career("Systems Engineering", 160);
         trafficLight = new AcademicTrafficLight(1, 0, career);
 
-        // Create test semester
         semester1 = new Semester(1, 2024, 2, false);
 
-        Group group1 = new Group(1, 1, 30, true, SubjectCatalog.getSubject("AYSR"), new Teacher("Dr. Carlos", "Martinez", 123456, "Systems Engineering"));
-        Enrollment enrollment1 = new Enrollment(group1, 1, "approved", 4.0);
-        Group group2 = new Group(2, 1, 30, true, SubjectCatalog.getSubject("DOPO"), new Teacher("Dr. Ana", "Lopez", 654321, "Systems Engineering"));
-        Enrollment enrollment2 = new Enrollment(group2, 1, "approved", 3.5);
-        Group group3 = new Group(3, 1, 30, true, SubjectCatalog.getSubject("CALD"), new Teacher("Dr. Juan", "Perez", 112233, "Mathematics"));
-        Enrollment enrollment3 = new Enrollment(group3, 1, "failed", 2.7);
+        Group group1 = new Group(1, 1, 30, true, new Teacher("Dr. Carlos", "Martinez", 123456, "Systems Engineering"));
+        Enrollment enrollment1 = new Enrollment(group1, SubjectCatalog.getSubject("AYSR"), 1, "approved", 4.0);
+
+        Group group2 = new Group(2, 1, 30, true, new Teacher("Dr. Ana", "Lopez", 654321, "Systems Engineering"));
+        Enrollment enrollment2 = new Enrollment(group2, SubjectCatalog.getSubject("DOPO"), 2, "approved", 3.5);
+
+        Group group3 = new Group(3, 1, 30, true, new Teacher("Dr. Juan", "Perez", 112233, "Mathematics"));
+        Enrollment enrollment3 = new Enrollment(group3, SubjectCatalog.getSubject("CALD"), 3, "failed", 2.7);
+
         semester1.addSubject(enrollment1);
         semester1.addSubject(enrollment2);
         semester1.addSubject(enrollment3);

--- a/src/test/java/com/example/fantasticosback/util/DeanOfficeTest.java
+++ b/src/test/java/com/example/fantasticosback/util/DeanOfficeTest.java
@@ -1,9 +1,5 @@
 package com.example.fantasticosback.util;
-
 import com.example.fantasticosback.Model.*;
-import com.example.fantasticosback.util.AcademicTrafficLight;
-import com.example.fantasticosback.util.ClassSession;
-import com.example.fantasticosback.util.SubjectCatalog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -41,10 +37,11 @@ public class DeanOfficeTest {
         subject1 = SubjectCatalog.getSubject("AYSR");
         subject2 = SubjectCatalog.getSubject("DOPO");
 
-        originGroup = new Group(1, 1, 25, true, subject1, teacher);
-        destinationGroup = new Group(2, 2, 30, true, subject1, teacher);
-        inactiveGroup = new Group(3, 3, 20, false, subject1, teacher);
-        fullGroup = new Group(4, 4, 0, true, subject2, teacher);
+        // Crear grupos sin referencia a subject
+        originGroup = new Group(1, 1, 25, true, teacher);
+        destinationGroup = new Group(2, 2, 30, true, teacher);
+        inactiveGroup = new Group(3, 3, 20, false, teacher);
+        fullGroup = new Group(4, 4, 0, true, teacher);
 
         originGroup.addSession(new ClassSession("Monday", "07:00", "08:30", "A-101"));
         destinationGroup.addSession(new ClassSession("Tuesday", "14:30", "16:00", "H-303"));
@@ -53,16 +50,18 @@ public class DeanOfficeTest {
 
         Semester semester = new Semester(1, 2025, 2, true);
         student.getSemesters().add(semester);
-        student.addSubject(originGroup);
+        student.addSubject(originGroup, subject1); // Ahora requiere tanto Group como Subject
 
         Enrollment originEnrollment = student.getSemesters().get(0).getSubjects().get(0);
-        groupChangeRequest = student.createRequest("group", originEnrollment, destinationGroup, "Change due to work schedule");
-        subjectChangeRequest = student.createRequest("subject", originEnrollment, fullGroup, "Career change");
+        groupChangeRequest = student.createRequest("group", originEnrollment, destinationGroup, subject1, "Change due to work schedule");
+        subjectChangeRequest = student.createRequest("subject", originEnrollment, fullGroup, subject2, "Career change");
     }
 
     @Test
     @DisplayName("Valid group change request should be approved")
     void testSuccessfulGroupChange() {
+        subject1.addGroup(destinationGroup);
+
         deanOffice.manageRequest(student, groupChangeRequest);
 
         assertEquals("Accepted", groupChangeRequest.getState().getStateName());
@@ -72,7 +71,7 @@ public class DeanOfficeTest {
     @DisplayName("Reject group change if group is inactive")
     void testGroupChangeInactiveGroup() {
         Request request = student.createRequest("group",
-                student.getSemesters().get(0).getSubjects().get(0), inactiveGroup, "Inactive destination");
+                student.getSemesters().get(0).getSubjects().get(0), inactiveGroup, subject1, "Inactive destination");
 
         deanOffice.manageRequest(student, request);
 
@@ -83,7 +82,7 @@ public class DeanOfficeTest {
     @DisplayName("Reject group change if no available spots")
     void testGroupChangeNoSpots() {
         Request request = student.createRequest("group",
-                student.getSemesters().get(0).getSubjects().get(0), fullGroup, "No spots");
+                student.getSemesters().get(0).getSubjects().get(0), fullGroup, subject2, "No spots");
 
         deanOffice.manageRequest(student, request);
 
@@ -93,12 +92,12 @@ public class DeanOfficeTest {
     @Test
     @DisplayName("Reject if there is schedule conflict")
     void testGroupChangeWithConflict() {
-        Group conflictGroup = new Group(6, 8, 25, true, subject2, teacher);
+        Group conflictGroup = new Group(6, 8, 25, true, teacher);
         conflictGroup.addSession(new ClassSession("Tuesday", "13:00", "16:00", "F-206"));
-        student.addSubject(conflictGroup);
+        student.addSubject(conflictGroup, subject2);
 
         Request request = student.createRequest("group",
-                student.getSemesters().get(0).getSubjects().get(0), destinationGroup, "Schedule conflict");
+                student.getSemesters().get(0).getSubjects().get(0), destinationGroup, subject1, "Schedule conflict");
 
         deanOffice.manageRequest(student, request);
 
@@ -108,11 +107,14 @@ public class DeanOfficeTest {
     @Test
     @DisplayName("Valid subject change is approved")
     void testSuccessfulSubjectChange() {
-        Group validDestinationGroup = new Group(7, 7, 30, true, subject2, teacher);
+        Subject catalogSubject = SubjectCatalog.getSubject("CALD"); // Usar una materia del catálogo
+        Group validDestinationGroup = new Group(7, 7, 30, true, teacher);
         validDestinationGroup.addSession(new ClassSession("Friday", "10:00", "11:30", "G-106"));
 
+        catalogSubject.addGroup(validDestinationGroup);
+
         Request request = student.createRequest("subject",
-                student.getSemesters().get(0).getSubjects().get(0), validDestinationGroup, "Valid change");
+                student.getSemesters().get(0).getSubjects().get(0), validDestinationGroup, catalogSubject, "Valid change");
 
         deanOffice.manageRequest(student, request);
 
@@ -122,11 +124,11 @@ public class DeanOfficeTest {
     @Test
     @DisplayName("Reject subject change if destination group is inactive")
     void testSubjectChangeInactiveGroup() {
-        Group inactiveSubject2Group = new Group(8, 8, 25, false, subject2, teacher);
+        Group inactiveSubject2Group = new Group(8, 8, 25, false, teacher);
         inactiveSubject2Group.addSession(new ClassSession("Saturday", "08:30", "10:00", "H-808"));
 
         Request request = student.createRequest("subject",
-                student.getSemesters().get(0).getSubjects().get(0), inactiveSubject2Group, "Inactive");
+                student.getSemesters().get(0).getSubjects().get(0), inactiveSubject2Group, subject2, "Inactive");
 
         deanOffice.manageRequest(student, request);
 
@@ -145,7 +147,7 @@ public class DeanOfficeTest {
     @DisplayName("Invalid request type should be rejected")
     void testInvalidType() {
         Request request = student.createRequest("other",
-                student.getSemesters().get(0).getSubjects().get(0), destinationGroup, "Invalid type");
+                student.getSemesters().get(0).getSubjects().get(0), destinationGroup, subject1, "Invalid type");
 
         deanOffice.manageRequest(student, request);
 
@@ -160,7 +162,7 @@ public class DeanOfficeTest {
         Student newStudent = new Student("Ana", "Lopez", 54321, "Medicine", "2022001", "est002", 1, tempTrafficLight);
 
         Enrollment originEnrollment = student.getSemesters().get(0).getSubjects().get(0);
-        Request request = newStudent.createRequest("group", originEnrollment, destinationGroup, "No semesters");
+        Request request = newStudent.createRequest("group", originEnrollment, destinationGroup, subject1, "No semesters");
 
         deanOffice.manageRequest(newStudent, request);
 
@@ -178,9 +180,9 @@ public class DeanOfficeTest {
         );
         deanOffice.addStudent(student1);
         student1.getSemesters().add(new Semester(1, 2025, 2, true));
-        student1.addSubject(originGroup);
+        student1.addSubject(originGroup, subject1);
         Enrollment enrollment1 = student1.getSemesters().get(0).getSubjects().get(0);
-        student1.createRequest("group", enrollment1, destinationGroup, "Schedule change");
+        student1.createRequest("group", enrollment1, destinationGroup, subject1, "Schedule change");
         assertEquals(3, deanOffice.getRequestsByFaculty().size());
     }
 }

--- a/src/test/java/com/example/fantasticosback/util/DeanOfficeTest.java
+++ b/src/test/java/com/example/fantasticosback/util/DeanOfficeTest.java
@@ -48,11 +48,12 @@ public class DeanOfficeTest {
         inactiveGroup.addSession(new ClassSession("Wednesday", "10:00", "11:30", "C-203"));
         fullGroup.addSession(new ClassSession("Thursday", "16:00", "17:30", "D-307"));
 
-        Semester semester = new Semester(1, 2025, 2, true);
-        student.getSemesters().add(semester);
-        student.addSubject(originGroup, subject1); // Ahora requiere tanto Group como Subject
+        // Agregar la materia al semestre actual (último semestre)
+        student.addSubject(originGroup, subject1);
 
-        Enrollment originEnrollment = student.getSemesters().get(0).getSubjects().get(0);
+        // Obtener el enrollment recién creado del semestre actual
+        Enrollment originEnrollment = student.getCurrentSchedule().get(0);
+
         groupChangeRequest = student.createRequest("group", originEnrollment, destinationGroup, subject1, "Change due to work schedule");
         subjectChangeRequest = student.createRequest("subject", originEnrollment, fullGroup, subject2, "Career change");
     }
@@ -71,7 +72,7 @@ public class DeanOfficeTest {
     @DisplayName("Reject group change if group is inactive")
     void testGroupChangeInactiveGroup() {
         Request request = student.createRequest("group",
-                student.getSemesters().get(0).getSubjects().get(0), inactiveGroup, subject1, "Inactive destination");
+                student.getCurrentSchedule().get(0), inactiveGroup, subject1, "Inactive destination");
 
         deanOffice.manageRequest(student, request);
 
@@ -82,7 +83,7 @@ public class DeanOfficeTest {
     @DisplayName("Reject group change if no available spots")
     void testGroupChangeNoSpots() {
         Request request = student.createRequest("group",
-                student.getSemesters().get(0).getSubjects().get(0), fullGroup, subject2, "No spots");
+                student.getCurrentSchedule().get(0), fullGroup, subject2, "No spots");
 
         deanOffice.manageRequest(student, request);
 
@@ -97,7 +98,7 @@ public class DeanOfficeTest {
         student.addSubject(conflictGroup, subject2);
 
         Request request = student.createRequest("group",
-                student.getSemesters().get(0).getSubjects().get(0), destinationGroup, subject1, "Schedule conflict");
+                student.getCurrentSchedule().get(0), destinationGroup, subject1, "Schedule conflict");
 
         deanOffice.manageRequest(student, request);
 
@@ -114,7 +115,7 @@ public class DeanOfficeTest {
         catalogSubject.addGroup(validDestinationGroup);
 
         Request request = student.createRequest("subject",
-                student.getSemesters().get(0).getSubjects().get(0), validDestinationGroup, catalogSubject, "Valid change");
+                student.getCurrentSchedule().get(0), validDestinationGroup, catalogSubject, "Valid change");
 
         deanOffice.manageRequest(student, request);
 
@@ -128,7 +129,7 @@ public class DeanOfficeTest {
         inactiveSubject2Group.addSession(new ClassSession("Saturday", "08:30", "10:00", "H-808"));
 
         Request request = student.createRequest("subject",
-                student.getSemesters().get(0).getSubjects().get(0), inactiveSubject2Group, subject2, "Inactive");
+                student.getCurrentSchedule().get(0), inactiveSubject2Group, subject2, "Inactive");
 
         deanOffice.manageRequest(student, request);
 
@@ -147,26 +148,11 @@ public class DeanOfficeTest {
     @DisplayName("Invalid request type should be rejected")
     void testInvalidType() {
         Request request = student.createRequest("other",
-                student.getSemesters().get(0).getSubjects().get(0), destinationGroup, subject1, "Invalid type");
+                student.getCurrentSchedule().get(0), destinationGroup, subject1, "Invalid type");
 
         deanOffice.manageRequest(student, request);
 
         assertEquals("Rejected", request.getState().getStateName());
-    }
-
-    @Test
-    @DisplayName("No conflict if student has no semesters")
-    void testNoSemesters() {
-        Career tempCareer = new Career("Medicine", 200);
-        AcademicTrafficLight tempTrafficLight = new AcademicTrafficLight(1, 0, tempCareer);
-        Student newStudent = new Student("Ana", "Lopez", 54321, "Medicine", "2022001", "est002", 1, tempTrafficLight);
-
-        Enrollment originEnrollment = student.getSemesters().get(0).getSubjects().get(0);
-        Request request = newStudent.createRequest("group", originEnrollment, destinationGroup, subject1, "No semesters");
-
-        deanOffice.manageRequest(newStudent, request);
-
-        assertEquals("Accepted", request.getState().getStateName());
     }
 
     @Test
@@ -179,10 +165,12 @@ public class DeanOfficeTest {
                 "2021002", "est003", 3, tempTrafficLight
         );
         deanOffice.addStudent(student1);
-        student1.getSemesters().add(new Semester(1, 2025, 2, true));
+
+        // Ya no necesitamos agregar semestre manualmente, ya se creó automáticamente
         student1.addSubject(originGroup, subject1);
-        Enrollment enrollment1 = student1.getSemesters().get(0).getSubjects().get(0);
+        Enrollment enrollment1 = student1.getCurrentSchedule().get(0);
         student1.createRequest("group", enrollment1, destinationGroup, subject1, "Schedule change");
+
         assertEquals(3, deanOffice.getRequestsByFaculty().size());
     }
 }

--- a/src/test/java/com/example/fantasticosback/util/EnrollmentTest.java
+++ b/src/test/java/com/example/fantasticosback/util/EnrollmentTest.java
@@ -25,19 +25,20 @@ public class EnrollmentTest {
         subject = new Subject("1", "Calculus I", 4, 1);
         teacher = new Teacher("Juan", "Perez", 12345678, "Mathematics");
 
-        group = new Group(1, 101, 30, true, subject, teacher);
+        group = new Group(1, 101, 30, true, teacher);
         session1 = new ClassSession("Monday", "08:00", "10:00", "A101");
         session2 = new ClassSession("Wednesday", "10:00", "12:00", "A102");
         group.addSession(session1);
         group.addSession(session2);
 
-        otherGroup = new Group(2, 102, 25, true, subject, teacher);
+        otherGroup = new Group(2, 102, 25, true, teacher);
         session3 = new ClassSession("Tuesday", "14:00", "16:00", "B201");
         session4 = new ClassSession("Thursday", "08:00", "10:00", "B202");
         otherGroup.addSession(session3);
         otherGroup.addSession(session4);
 
-        enrollment = new Enrollment(group, 1, "enrolled", 0.0);
+        // Crear enrollment con subject y group
+        enrollment = new Enrollment(group, subject, 1, "enrolled", 0.0);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class EnrollmentTest {
 
     @Test
     void testConstructorWithVariousParameters() {
-        Enrollment enrollment2 = new Enrollment(otherGroup, 999, "passed", 45.5);
+        Enrollment enrollment2 = new Enrollment(otherGroup, subject, 999, "passed", 45.5);
 
         assertEquals(otherGroup, enrollment2.getGroup());
         assertEquals(999, enrollment2.getId());
@@ -60,7 +61,7 @@ public class EnrollmentTest {
 
     @Test
     void testConstructorWithNullGroup() {
-        Enrollment nullEnrollment = new Enrollment(null, 2, "pending", 25.0);
+        Enrollment nullEnrollment = new Enrollment(null, subject, 2, "pending", 25.0);
 
         assertNull(nullEnrollment.getGroup());
         assertEquals(2, nullEnrollment.getId());
@@ -96,37 +97,37 @@ public class EnrollmentTest {
         assertEquals("cancelled", enrollment.getStatus());
 
         // Verify that cancel from another status also works
-        Enrollment passedEnrollment = new Enrollment(group, 2, "passed", 40.0);
+        Enrollment passedEnrollment = new Enrollment(group, subject, 2, "passed", 40.0);
         passedEnrollment.cancel();
         assertEquals("cancelled", passedEnrollment.getStatus());
     }
 
     @Test
     void testEvaluatePassed() {
-        Enrollment passedEnrollment = new Enrollment(group, 2, "enrolled", 30.0);
+        Enrollment passedEnrollment = new Enrollment(group, subject, 2, "enrolled", 30.0);
         passedEnrollment.evaluate();
-        assertEquals("approved", passedEnrollment.getStatus()); // Changed from "passed" to "approved"
+        assertEquals("approved", passedEnrollment.getStatus());
 
-        Enrollment highGradeEnrollment = new Enrollment(group, 3, "enrolled", 45.5);
+        Enrollment highGradeEnrollment = new Enrollment(group, subject, 3, "enrolled", 45.5);
         highGradeEnrollment.evaluate();
-        assertEquals("approved", highGradeEnrollment.getStatus()); // Changed from "passed" to "approved"
+        assertEquals("approved", highGradeEnrollment.getStatus());
 
-        Enrollment limitEnrollment = new Enrollment(group, 4, "enrolled", 30.0);
+        Enrollment limitEnrollment = new Enrollment(group, subject, 4, "enrolled", 30.0);
         limitEnrollment.evaluate();
-        assertEquals("approved", limitEnrollment.getStatus()); // Changed from "passed" to "approved"
+        assertEquals("approved", limitEnrollment.getStatus());
     }
 
     @Test
     void testEvaluateFailed() {
-        Enrollment failedEnrollment = new Enrollment(group, 2, "enrolled", 29.9);
+        Enrollment failedEnrollment = new Enrollment(group, subject, 2, "enrolled", 29.9);
         failedEnrollment.evaluate();
         assertEquals("failed", failedEnrollment.getStatus());
 
-        Enrollment lowGradeEnrollment = new Enrollment(group, 3, "enrolled", 0.0);
+        Enrollment lowGradeEnrollment = new Enrollment(group, subject, 3, "enrolled", 0.0);
         lowGradeEnrollment.evaluate();
         assertEquals("failed", lowGradeEnrollment.getStatus());
 
-        Enrollment negativeGradeEnrollment = new Enrollment(group, 4, "enrolled", -5.0);
+        Enrollment negativeGradeEnrollment = new Enrollment(group, subject, 4, "enrolled", -5.0);
         negativeGradeEnrollment.evaluate();
         assertEquals("failed", negativeGradeEnrollment.getStatus());
     }
@@ -145,7 +146,7 @@ public class EnrollmentTest {
     @Test
     void testValidateConflictNoConflict() {
         // Create enrollment with schedules that don't conflict
-        Enrollment otherEnrollment = new Enrollment(otherGroup, 2, "enrolled", 0.0);
+        Enrollment otherEnrollment = new Enrollment(otherGroup, subject, 2, "enrolled", 0.0);
 
         // The schedules are different: Monday 08:00-10:00, Wednesday 10:00-12:00 vs Tuesday 14:00-16:00, Thursday 08:00-10:00
         assertFalse(enrollment.validateConflict(otherEnrollment));
@@ -155,11 +156,11 @@ public class EnrollmentTest {
     @Test
     void testValidateConflictHasConflict() {
         // Create group with conflicting schedule
-        Group conflictGroup = new Group(3, 103, 20, true, subject, teacher);
+        Group conflictGroup = new Group(3, 103, 20, true, teacher);
         ClassSession conflictSession = new ClassSession("Monday", "08:00", "09:00", "C301");
         conflictGroup.addSession(conflictSession);
 
-        Enrollment conflictEnrollment = new Enrollment(conflictGroup, 3, "enrolled", 0.0);
+        Enrollment conflictEnrollment = new Enrollment(conflictGroup, subject, 3, "enrolled", 0.0);
 
         // Should have conflict because both have Monday session at 08:00
         assertTrue(enrollment.validateConflict(conflictEnrollment));
@@ -168,11 +169,11 @@ public class EnrollmentTest {
 
     @Test
     void testValidateConflictSameEndTime() {
-        Group finalConflictGroup = new Group(4, 104, 15, true, subject, teacher);
+        Group finalConflictGroup = new Group(4, 104, 15, true, teacher);
         ClassSession finalConflictSession = new ClassSession("Monday", "09:00", "10:00", "D401");
         finalConflictGroup.addSession(finalConflictSession);
 
-        Enrollment finalConflictEnrollment = new Enrollment(finalConflictGroup, 4, "enrolled", 0.0);
+        Enrollment finalConflictEnrollment = new Enrollment(finalConflictGroup, subject, 4, "enrolled", 0.0);
 
         assertTrue(enrollment.validateConflict(finalConflictEnrollment));
         assertTrue(finalConflictEnrollment.validateConflict(enrollment));
@@ -181,8 +182,8 @@ public class EnrollmentTest {
     @Test
     void testValidateConflictGroupWithoutSessions() {
         // Create group without sessions
-        Group emptyGroup = new Group(5, 105, 10, true, subject, teacher);
-        Enrollment emptyEnrollment = new Enrollment(emptyGroup, 5, "enrolled", 0.0);
+        Group emptyGroup = new Group(5, 105, 10, true, teacher);
+        Enrollment emptyEnrollment = new Enrollment(emptyGroup, subject, 5, "enrolled", 0.0);
 
         // Should not have conflict if one of the groups has no sessions
         assertFalse(enrollment.validateConflict(emptyEnrollment));
@@ -191,11 +192,11 @@ public class EnrollmentTest {
 
     @Test
     void testValidateConflictBothGroupsWithoutSessions() {
-        Group emptyGroup1 = new Group(6, 106, 10, true, subject, teacher);
-        Group emptyGroup2 = new Group(7, 107, 10, true, subject, teacher);
+        Group emptyGroup1 = new Group(6, 106, 10, true, teacher);
+        Group emptyGroup2 = new Group(7, 107, 10, true, teacher);
 
-        Enrollment emptyEnrollment1 = new Enrollment(emptyGroup1, 6, "enrolled", 0.0);
-        Enrollment emptyEnrollment2 = new Enrollment(emptyGroup2, 7, "enrolled", 0.0);
+        Enrollment emptyEnrollment1 = new Enrollment(emptyGroup1, subject, 6, "enrolled", 0.0);
+        Enrollment emptyEnrollment2 = new Enrollment(emptyGroup2, subject, 7, "enrolled", 0.0);
 
         assertFalse(emptyEnrollment1.validateConflict(emptyEnrollment2));
         assertFalse(emptyEnrollment2.validateConflict(emptyEnrollment1));

--- a/src/test/java/com/example/fantasticosback/util/GroupTest.java
+++ b/src/test/java/com/example/fantasticosback/util/GroupTest.java
@@ -21,7 +21,7 @@ public class GroupTest {
     void setUp() {
         subject = new Subject("1", "Calculus I", 4, 1);
         teacher = new Teacher("John", "Perez", 12345678, "Mathematics");
-        group = new Group(1, 101, 30, true, subject, teacher);
+        group = new Group(1, 101, 30, true, teacher); // Eliminado el parámetro subject
 
         session1 = new ClassSession("Monday", "08:00", "10:00", "A101");
         session2 = new ClassSession("Wednesday", "10:00", "12:00", "A102");
@@ -33,20 +33,20 @@ public class GroupTest {
         assertEquals(101, group.getNumber());
         assertEquals(30, group.getCapacity());
         assertTrue(group.isActive());
-        assertEquals(subject, group.getSubject());
+        assertEquals(teacher, group.getTeacher()); // Cambiado de getSubject() a getTeacher()
         assertNotNull(group.getSessions());
         assertTrue(group.getSessions().isEmpty());
     }
 
     @Test
     void testGroupCreationWithNulls() {
-        Group groupWithNulls = new Group(2, 102, 25, false, null, null);
+        Group groupWithNulls = new Group(2, 102, 25, false, null); // Eliminado el parámetro subject
 
         assertEquals(2, groupWithNulls.getId());
         assertEquals(102, groupWithNulls.getNumber());
         assertEquals(25, groupWithNulls.getCapacity());
         assertFalse(groupWithNulls.isActive());
-        assertNull(groupWithNulls.getSubject());
+        assertNull(groupWithNulls.getTeacher()); // Cambiado de getSubject() a getTeacher()
         assertNotNull(groupWithNulls.getSessions());
         assertTrue(groupWithNulls.getSessions().isEmpty());
     }
@@ -73,13 +73,13 @@ public class GroupTest {
     }
 
     @Test
-    void testSetSubject() {
-        Subject newSubject = new Subject("2", "Physics I", 3, 2);
-        group.setSubject(newSubject);
-        assertEquals(newSubject, group.getSubject());
+    void testSetTeacher() {
+        Teacher newTeacher = new Teacher("Maria", "Lopez", 87654321, "Physics");
+        group.setTeacher(newTeacher);
+        assertEquals(newTeacher, group.getTeacher());
 
-        group.setSubject(null);
-        assertNull(group.getSubject());
+        group.setTeacher(null);
+        assertNull(group.getTeacher());
     }
 
     @Test
@@ -136,33 +136,33 @@ public class GroupTest {
 
     @Test
     void testActiveState() {
-        Group activeGroup = new Group(1, 101, 30, true, subject, teacher);
+        Group activeGroup = new Group(1, 101, 30, true, teacher); // Eliminado el parámetro subject
         assertTrue(activeGroup.isActive());
-        Group inactiveGroup = new Group(2, 102, 25, false, subject, teacher);
+        Group inactiveGroup = new Group(2, 102, 25, false, teacher); // Eliminado el parámetro subject
         assertFalse(inactiveGroup.isActive());
     }
 
     @Test
     void testCapacityVariations() {
-        Group groupCapacity50 = new Group(1, 101, 50, true, subject, teacher);
+        Group groupCapacity50 = new Group(1, 101, 50, true, teacher); // Eliminado el parámetro subject
         assertEquals(50, groupCapacity50.getCapacity());
 
-        Group groupCapacity0 = new Group(2, 102, 0, true, subject, teacher);
+        Group groupCapacity0 = new Group(2, 102, 0, true, teacher); // Eliminado el parámetro subject
         assertEquals(0, groupCapacity0.getCapacity());
 
-        Group groupNegativeCapacity = new Group(3, 103, -5, true, subject, teacher);
+        Group groupNegativeCapacity = new Group(3, 103, -5, true, teacher); // Eliminado el parámetro subject
         assertEquals(-5, groupNegativeCapacity.getCapacity());
     }
 
     @Test
     void testNumberVariations() {
-        Group group1 = new Group(1, 101, 30, true, subject, teacher);
+        Group group1 = new Group(1, 101, 30, true, teacher); // Eliminado el parámetro subject
         assertEquals(101, group1.getNumber());
 
-        Group group2 = new Group(2, 999, 30, true, subject, teacher);
+        Group group2 = new Group(2, 999, 30, true, teacher); // Eliminado el parámetro subject
         assertEquals(999, group2.getNumber());
 
-        Group group3 = new Group(3, 0, 30, true, subject, teacher);
+        Group group3 = new Group(3, 0, 30, true, teacher); // Eliminado el parámetro subject
         assertEquals(0, group3.getNumber());
     }
 }

--- a/src/test/java/com/example/fantasticosback/util/ObserverTest.java
+++ b/src/test/java/com/example/fantasticosback/util/ObserverTest.java
@@ -2,12 +2,8 @@ package com.example.fantasticosback.util;
 
 import com.example.fantasticosback.Model.*;
 import com.example.fantasticosback.Model.Observers.DeanObserver;
-import com.example.fantasticosback.Model.Observers.RequestObserver;
 import com.example.fantasticosback.Model.Observers.StudentObserver;
-import com.example.fantasticosback.util.SubjectCatalog;
-import com.example.fantasticosback.util.AcademicTrafficLight;
 import org.junit.jupiter.api.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Date;
@@ -28,7 +24,6 @@ public class ObserverTest {
         AcademicTrafficLight trafficLight = new AcademicTrafficLight(1, 0, career);
         Student student = new Student("Ana", "Garcia", 123456, "Engineering", "202301", "E01", 5, trafficLight);
 
-        // Make the addObserver method public in Student
         student.addObserver(deanObserver);
         Subject subject1 = SubjectCatalog.getSubject("AYSR");
         Subject subject2 = SubjectCatalog.getSubject("DOPO");

--- a/src/test/java/com/example/fantasticosback/util/ObserverTest.java
+++ b/src/test/java/com/example/fantasticosback/util/ObserverTest.java
@@ -34,12 +34,12 @@ public class ObserverTest {
         Subject subject2 = SubjectCatalog.getSubject("DOPO");
         Teacher teacher = new Teacher("Dr. Carlos", "Martinez", 123456, "Systems Engineering");
 
-        Group originGroup = new Group(1, 1, 25, true, subject1, teacher);
-        Group destinationGroup = new Group(2, 2, 30, true, subject2, teacher);
-        Enrollment currentEnrollment = new Enrollment(originGroup, 1, "enrolled", 0.0);
+        Group originGroup = new Group(1, 1, 25, true, teacher); // Eliminado el parámetro subject
+        Group destinationGroup = new Group(2, 2, 30, true, teacher); // Eliminado el parámetro subject
+        Enrollment currentEnrollment = new Enrollment(originGroup, subject1, 1, "enrolled", 0.0); // Agregado subject
 
         // Act
-        student.createRequest("group", currentEnrollment, destinationGroup, "Change due to schedule conflict");
+        student.createRequest("group", currentEnrollment, destinationGroup, subject2, "Change due to schedule conflict"); // Agregado destinationSubject
 
         // Restore standard output
         System.setOut(originalOut);
@@ -69,10 +69,10 @@ public class ObserverTest {
         Subject subject1 = SubjectCatalog.getSubject("AYSR");
         Subject subject2 = SubjectCatalog.getSubject("DOPO");
         Teacher teacher = new Teacher("Dr. Carlos", "Martinez", 123456, "Systems Engineering");
-        Group originGroup = new Group(1, 1, 25, true, subject1, teacher);
-        Group destinationGroup = new Group(2, 2, 30, true, subject2, teacher);
+        Group originGroup = new Group(1, 1, 25, true, teacher); // Eliminado el parámetro subject
+        Group destinationGroup = new Group(2, 2, 30, true, teacher); // Eliminado el parámetro subject
 
-        Enrollment enrollment = new Enrollment(originGroup, 1, "active", 0.0);
+        Enrollment enrollment = new Enrollment(originGroup, subject1, 1, "active", 0.0); // Agregado subject
 
         Request request = new Request(
                 "555",

--- a/src/test/java/com/example/fantasticosback/util/SemesterTest.java
+++ b/src/test/java/com/example/fantasticosback/util/SemesterTest.java
@@ -23,17 +23,17 @@ public class SemesterTest {
     void setUp() {
         semester = new Semester();
 
-        // Create real objects for testing
+
         teacher = new Teacher("Juan", "Perez", 12345678, "Systems");
 
         subject1 = new Subject("101", "Mathematics", 3, 1);
         subject2 = new Subject("102", "Physics", 4, 2);
 
-        group1 = new Group(1, 1, 30, true, subject1, teacher);
-        group2 = new Group(2, 2, 25, true, subject2, teacher);
+        group1 = new Group(1, 1, 30, true, teacher);
+        group2 = new Group(2, 2, 25, true, teacher);
 
-        enrollment1 = new Enrollment(group1, 1, "active", 4.0);
-        enrollment2 = new Enrollment(group2, 2, "active", 3.5);
+        enrollment1 = new Enrollment(group1, subject1, 1, "active", 4.0);
+        enrollment2 = new Enrollment(group2, subject2, 2, "active", 3.5);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class SemesterTest {
         semester.addSubject(enrollment1);
         int initialSize = semester.getSubjects().size();
 
-        Enrollment nonExistentEnrollment = new Enrollment(group2, 99, "active", 3.0);
+        Enrollment nonExistentEnrollment = new Enrollment(group2, subject2, 99, "active", 3.0);
         semester.removeSubject(nonExistentEnrollment);
 
         assertEquals(initialSize, semester.getSubjects().size());
@@ -135,8 +135,8 @@ public class SemesterTest {
 
     @Test
     void testCalculateSemesterAverageWithExtremeGrades() {
-        Enrollment highGradeEnrollment = new Enrollment(group1, 3, "active", 5.0); // 3 credits
-        Enrollment lowGradeEnrollment = new Enrollment(group2, 4, "active", 1.0);  // 4 credits
+        Enrollment highGradeEnrollment = new Enrollment(group1, subject1, 3, "active", 5.0); // 3 credits
+        Enrollment lowGradeEnrollment = new Enrollment(group2, subject2, 4, "active", 1.0);  // 4 credits
 
         semester.addSubject(highGradeEnrollment);
         semester.addSubject(lowGradeEnrollment);


### PR DESCRIPTION
- Remueve campo 'subject' de la clase Group para evitar StackOverflowError
- Modifica Enrollment para incluir referencias directas a Subject y Group
- Actualiza constructores en Student, Semester, AcademicTrafficLight y servicios
- Corrige métodos que usaban getGroup().getSubject() por getSubject()
- Optimiza findSubjectByGroupId() usando streams en lugar de bucles anidados
- Se actualiza todas las clases de test para usar la nueva estructura