### PR TITLE
feat: agregar endpoint de grupos de profesor y gestión de usuarios admin

### DIFF
--- a/src/main/java/com/example/fantasticosback/controller/AdminController.java
+++ b/src/main/java/com/example/fantasticosback/controller/AdminController.java
@@ -184,6 +184,66 @@ public class AdminController {
         return ResponseEntity.ok(ResponseDTO.success(null, "User deleted by admin"));
     }
 
+    @Operation(
+        summary = "Actualizar rol de usuario",
+        description = "Admin actualiza el rol y/o profileId de un usuario existente"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Rol actualizado exitosamente"),
+        @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
+    })
+    @PatchMapping("/users/{email}/role")
+    public ResponseEntity<ResponseDTO<UserResponseDTO>> updateUserRole(
+            @Parameter(description = "Email del usuario") @PathVariable String email,
+            @Parameter(description = "Nuevo rol") @RequestParam(required = false) com.example.fantasticosback.enums.Role role,
+            @Parameter(description = "Nuevo profileId") @RequestParam(required = false) String profileId) {
+        
+        User user = userRepository.findByEmail(email).orElseThrow(
+            () -> new RuntimeException("User not found with email: " + email)
+        );
+
+        if (role != null) {
+            user.setRole(role);
+        }
+        
+        if (profileId != null) {
+            user.setProfileId(profileId);
+        }
+
+        User updated = userRepository.save(user);
+
+        UserResponseDTO response = new UserResponseDTO(
+                updated.getEmail(),
+                updated.getRole(),
+                updated.getProfileId()
+        );
+
+        return ResponseEntity.ok(ResponseDTO.success(response, "User role/profile updated by admin"));
+    }
+
+    @Operation(
+        summary = "Actualizar contraseña de usuario",
+        description = "Admin actualiza la contraseña de un usuario (será hasheada automáticamente)"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Contraseña actualizada exitosamente"),
+        @ApiResponse(responseCode = "404", description = "Usuario no encontrado")
+    })
+    @PatchMapping("/users/{email}/password")
+    public ResponseEntity<ResponseDTO<String>> updateUserPassword(
+            @Parameter(description = "Email del usuario") @PathVariable String email,
+            @Parameter(description = "Nueva contraseña") @RequestParam String newPassword) {
+        
+        User user = userRepository.findByEmail(email).orElseThrow(
+            () -> new RuntimeException("User not found with email: " + email)
+        );
+
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        return ResponseEntity.ok(ResponseDTO.success("Password updated", "Password updated successfully for user: " + email));
+    }
+
     // ========== GESTIÓN DE DECANOS ==========
 
     @Operation(summary = "Crear decano", description = "Admin crea nuevo decano")

--- a/src/main/java/com/example/fantasticosback/repository/GroupRepository.java
+++ b/src/main/java/com/example/fantasticosback/repository/GroupRepository.java
@@ -12,6 +12,9 @@ public interface GroupRepository extends MongoRepository<Group, String> {
     List<Group> findBySubjectId(String subjectId);
     List<Group> findAllByNumber(int number);
 
+    @Query("{ 'teacher._id': ?0 }")
+    List<Group> findByTeacherId(String teacherId);
+
     default boolean existsByNumber(int number) {
         return !findAllByNumber(number).isEmpty();
     }

--- a/src/main/java/com/example/fantasticosback/service/GroupService.java
+++ b/src/main/java/com/example/fantasticosback/service/GroupService.java
@@ -117,6 +117,17 @@ public class GroupService {
         return studentRepository.findAllById(studentIds);
     }
 
+    /**
+     * Obtiene todos los grupos asignados a un profesor específico.
+     * @param teacherId ID del profesor
+     * @return Lista de grupos del profesor
+     */
+    public List<Group> getGroupsByTeacherId(String teacherId) {
+        // Validar que el profesor existe
+        teacherService.findById(teacherId);
+        return groupRepository.findByTeacherId(teacherId);
+    }
+
 
     private void validateGroupCreation(Group group) {
         if (group.getCapacity() <= 0) {


### PR DESCRIPTION
- Agregar endpoint GET /api/teachers/{teacherId}/groups para obtener grupos asignados a un profesor
- Agregar método de consulta findByTeacherId en GroupRepository usando query de MongoDB
- Agregar método de servicio getGroupsByTeacherId en GroupService con validación de profesor
- Inyectar dependencia GroupService en TeacherController
- Agregar endpoint PATCH /api/admin/users/{email}/role para actualizar rol y profileId de usuario
- Agregar endpoint PATCH /api/admin/users/{email}/password para actualizar y hashear contraseña de usuario
- Corregir problema de mapeo de rol de profesor para autenticación
- Agregar documentación completa de Swagger para todos los nuevos endpoints